### PR TITLE
Juju 7400 integrate model watcher

### DIFF
--- a/domain/controller/service/package_mock_test.go
+++ b/domain/controller/service/package_mock_test.go
@@ -40,44 +40,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AllModelActivationStatusQuery mocks base method.
-func (m *MockState) AllModelActivationStatusQuery() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllModelActivationStatusQuery")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// AllModelActivationStatusQuery indicates an expected call of AllModelActivationStatusQuery.
-func (mr *MockStateMockRecorder) AllModelActivationStatusQuery() *MockStateAllModelActivationStatusQueryCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelActivationStatusQuery", reflect.TypeOf((*MockState)(nil).AllModelActivationStatusQuery))
-	return &MockStateAllModelActivationStatusQueryCall{Call: call}
-}
-
-// MockStateAllModelActivationStatusQueryCall wrap *gomock.Call
-type MockStateAllModelActivationStatusQueryCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateAllModelActivationStatusQueryCall) Return(arg0 string) *MockStateAllModelActivationStatusQueryCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateAllModelActivationStatusQueryCall) Do(f func() string) *MockStateAllModelActivationStatusQueryCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAllModelActivationStatusQueryCall) DoAndReturn(f func() string) *MockStateAllModelActivationStatusQueryCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // ControllerModelUUID mocks base method.
 func (m *MockState) ControllerModelUUID(arg0 context.Context) (model.UUID, error) {
 	m.ctrl.T.Helper()

--- a/domain/controller/service/package_mock_test.go
+++ b/domain/controller/service/package_mock_test.go
@@ -40,6 +40,44 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// AllModelActivationStatusQuery mocks base method.
+func (m *MockState) AllModelActivationStatusQuery() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllModelActivationStatusQuery")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// AllModelActivationStatusQuery indicates an expected call of AllModelActivationStatusQuery.
+func (mr *MockStateMockRecorder) AllModelActivationStatusQuery() *MockStateAllModelActivationStatusQueryCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelActivationStatusQuery", reflect.TypeOf((*MockState)(nil).AllModelActivationStatusQuery))
+	return &MockStateAllModelActivationStatusQueryCall{Call: call}
+}
+
+// MockStateAllModelActivationStatusQueryCall wrap *gomock.Call
+type MockStateAllModelActivationStatusQueryCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllModelActivationStatusQueryCall) Return(arg0 string) *MockStateAllModelActivationStatusQueryCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllModelActivationStatusQueryCall) Do(f func() string) *MockStateAllModelActivationStatusQueryCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllModelActivationStatusQueryCall) DoAndReturn(f func() string) *MockStateAllModelActivationStatusQueryCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ControllerModelUUID mocks base method.
 func (m *MockState) ControllerModelUUID(arg0 context.Context) (model.UUID, error) {
 	m.ctrl.T.Helper()
@@ -75,6 +113,45 @@ func (c *MockStateControllerModelUUIDCall) Do(f func(context.Context) (model.UUI
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateControllerModelUUIDCall) DoAndReturn(f func(context.Context) (model.UUID, error)) *MockStateControllerModelUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetModelActivationStatus mocks base method.
+func (m *MockState) GetModelActivationStatus(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModelActivationStatus", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetModelActivationStatus indicates an expected call of GetModelActivationStatus.
+func (mr *MockStateMockRecorder) GetModelActivationStatus(arg0, arg1 any) *MockStateGetModelActivationStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModelActivationStatus", reflect.TypeOf((*MockState)(nil).GetModelActivationStatus), arg0, arg1)
+	return &MockStateGetModelActivationStatusCall{Call: call}
+}
+
+// MockStateGetModelActivationStatusCall wrap *gomock.Call
+type MockStateGetModelActivationStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetModelActivationStatusCall) Return(arg0 bool, arg1 error) *MockStateGetModelActivationStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetModelActivationStatusCall) Do(f func(context.Context, string) (bool, error)) *MockStateGetModelActivationStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetModelActivationStatusCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockStateGetModelActivationStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/controller/service/service.go
+++ b/domain/controller/service/service.go
@@ -5,28 +5,102 @@ package service
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
+	"github.com/juju/juju/domain/controller/state"
+	"github.com/juju/juju/internal/logger"
 )
+
+var log = logger.GetLogger("juju.domain.controller.service")
 
 // State defines an interface for interacting with the underlying state.
 type State interface {
 	ControllerModelUUID(ctx context.Context) (model.UUID, error)
+	AllModelActivationStatusQuery() string
+	GetModelActivationStatus(ctx context.Context, controllerModelUUID string) (bool, error)
+	GetControllerModel(ctx context.Context, controllerUUID string) (*state.ControllerModel, error)
+}
+
+// WatcherFactory describes methods for creating watchers.
+type WatcherFactory interface {
+	// NewNamespaceWatcher returns a new namespace watcher
+	// for events based on the input change mask.
+	// InitialStateQuery can be used to select only the columns that you want to observe.
+	NewNamespaceMapperWatcher(
+		namespace string, changeMask changestream.ChangeType, initialStateQuery eventsource.NamespaceQuery, mapper eventsource.Mapper,
+	) (watcher.StringsWatcher, error)
+
+	NewNamespaceNotifyMapperWatcher(
+		namespace string, changeMask changestream.ChangeType, mapper eventsource.Mapper,
+	) (watcher.NotifyWatcher, error)
+}
+
+type WatcherFactoryGetter interface {
+	GetWatcherFactory() WatcherFactory
 }
 
 // Service defines a service for interacting with the underlying state.
 type Service struct {
-	st State
+	st             State
+	watcherFactory WatcherFactory
 }
 
 // NewService returns a new Service for interacting with the underlying state.
-func NewService(st State) *Service {
+func NewService(st State, watcherFactory WatcherFactory) *Service {
 	return &Service{
-		st: st,
+		st:             st,
+		watcherFactory: watcherFactory,
 	}
 }
 
 // ControllerModelUUID returns the model UUID of the controller model.
 func (s *Service) ControllerModelUUID(ctx context.Context) (model.UUID, error) {
 	return s.st.ControllerModelUUID(ctx)
+}
+
+// Watch returns a watcher that returns keys for any changes to model.
+func (s *Service) Watch(ctx context.Context) (watcher.StringsWatcher, error) {
+	mapper := func(ctx context.Context, db database.TxnRunner, changes []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
+		activatedChanges := make([]changestream.ChangeEvent, 0, len(changes))
+		fmt.Printf("watched alvin \n")
+		for _, change := range changes {
+			fmt.Printf("changed: %+v\n", change)
+
+			controllerModelUUID := change.Changed()
+
+			change.Namespace()
+			modelActivationStatus, err := s.st.GetModelActivationStatus(ctx, controllerModelUUID)
+			if err != nil {
+				log.Errorf(ctx, "failed to get model activation status: %v\n", err)
+				continue
+			}
+
+			// model, err := s.st.GetControllerModel(ctx, controllerModelUUID)
+			// if err != nil {
+			// 	log.Errorf(ctx, "failed to get controller model: %v\n", err)
+			// 	continue
+			// }
+			// fmt.Printf("current model: %+v\n", model)
+
+			if modelActivationStatus {
+				activatedChanges = append(activatedChanges, change)
+			}
+		}
+		return activatedChanges, nil
+	}
+
+	return s.watcherFactory.NewNamespaceMapperWatcher(
+		"model", changestream.All,
+		eventsource.InitialNamespaceChanges(s.st.AllModelActivationStatusQuery()),
+		mapper,
+	)
+	// return s.watcherFactory.NewNamespaceNotifyMapperWatcher(
+	// 	"model", changestream.All,
+	// 	mapper,
+	// )
 }

--- a/domain/controller/service/service_test.go
+++ b/domain/controller/service/service_test.go
@@ -30,7 +30,7 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *serviceSuite) TestControllerModelUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	st := NewService(s.state)
+	st := NewService(s.state, nil)
 	controllerModelUUID := model.UUID(jujutesting.ModelTag.Id())
 	s.state.EXPECT().ControllerModelUUID(gomock.Any()).Return(controllerModelUUID, nil)
 	uuid, err := st.ControllerModelUUID(context.Background())

--- a/domain/controller/state/state.go
+++ b/domain/controller/state/state.go
@@ -94,3 +94,7 @@ WHERE  uuid = $controllerModel.uuid
 
 	return m.Activated, err
 }
+
+func (st *State) AllModelActivationStatusQuery() string {
+	return "SELECT activated from model"
+}

--- a/domain/controller/state/state_test.go
+++ b/domain/controller/state/state_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	coremodel "github.com/juju/juju/core/model"
+	modeltesting "github.com/juju/juju/domain/model/state/testing"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	jujutesting "github.com/juju/juju/internal/testing"
 )
@@ -32,4 +33,12 @@ func (s *stateSuite) TestControllerModelUUID(c *gc.C) {
 	uuid, err := st.ControllerModelUUID(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uuid, gc.Equals, s.controllerModelUUID)
+}
+
+func (s *stateSuite) TestGetModelActivationStatus(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	uuid := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "test-controller")
+	activated, err := st.GetModelActivationStatus(context.Background(), uuid.String())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(activated, jc.IsTrue)
 }

--- a/domain/controller/watcher_test.go
+++ b/domain/controller/watcher_test.go
@@ -127,20 +127,7 @@ func (s *watcherSuite) TestWatchController(c *gc.C) {
 	c.Check(testModel.Activated, jc.IsFalse)
 
 	wc := watchertest.NewNotifyWatcherC(c, watcher)
-	// s.updateModelActiveStatus(c, modelUUIDStr, true)
-	// wc.AssertOneChange()
-
-	// s.updateModelName(c, modelUUIDStr, "new-name")
-	// wc.AssertOneChange()
-
-	// dbInitialModel := modeltesting.DbInitialModel{
-	// 	UUID: modelUUIDStr,
-	// }
-	// modeltesting.DeleteTestModel(c, s.TxnRunnerFactory(), dbInitialModel)
-	// wc.AssertOneChange()
-
-	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		defer tx.Rollback()
+	s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, "UPDATE model SET activated = ? WHERE uuid = ?", true, modelUUIDStr)
 		c.Assert(err, jc.ErrorIsNil)
 		rowsAffected, err := res.RowsAffected()
@@ -164,15 +151,29 @@ func (s *watcherSuite) TestWatchController(c *gc.C) {
 
 		err = tx.Commit()
 		c.Assert(err, jc.ErrorIsNil)
-		return err
+		return nil
 	})
-	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNChanges(2)
 
-	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		defer tx.Rollback()
+	// modeltesting.DeleteTestModel(c, s.TxnRunnerFactory(), modeltesting.DbInitialModel{
+	// 	UUID:      modelUUIDStr,
+	// 	OwnerUUID: testModel.OwnerUUID,
+	// 	CloudUUID: testModel.CloudUUID,
+	// })
+	s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		// res, err := tx.ExecContext(ctx, "DELETE from user_authentication WHERE user_uuid = ?", testModel.OwnerUUID)
+		// c.Assert(err, jc.ErrorIsNil)
+		// rowsAffected, err := res.RowsAffected()
+		// c.Assert(err, jc.ErrorIsNil)
+		// c.Check(int(rowsAffected), gc.Equals, 1)
 
-		res, err := tx.ExecContext(ctx, "DELETE from user WHERE uuid = ?", testModel.OwnerUUID)
+		// res, err = tx.ExecContext(ctx, "DELETE from user WHERE uuid = ?", testModel.OwnerUUID)
+		// c.Assert(err, jc.ErrorIsNil)
+		// rowsAffected, err = res.RowsAffected()
+		// c.Assert(err, jc.ErrorIsNil)
+		// c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err := tx.ExecContext(ctx, "DELETE from cloud WHERE uuid = ?", testModel.CloudUUID)
 		c.Assert(err, jc.ErrorIsNil)
 		rowsAffected, err := res.RowsAffected()
 		c.Assert(err, jc.ErrorIsNil)
@@ -190,12 +191,6 @@ func (s *watcherSuite) TestWatchController(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(int(rowsAffected), gc.Equals, 1)
 
-		res, err = tx.ExecContext(ctx, "DELETE from cloud WHERE uuid = ?", testModel.CloudUUID)
-		c.Assert(err, jc.ErrorIsNil)
-		rowsAffected, err = res.RowsAffected()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(int(rowsAffected), gc.Equals, 1)
-
 		res, err = tx.ExecContext(ctx, "DELETE from model WHERE uuid = ?", testModel.UUID)
 		c.Assert(err, jc.ErrorIsNil)
 		rowsAffected, err = res.RowsAffected()
@@ -204,8 +199,7 @@ func (s *watcherSuite) TestWatchController(c *gc.C) {
 
 		err = tx.Commit()
 		c.Assert(err, jc.ErrorIsNil)
-		return err
+		return nil
 	})
-	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 }

--- a/domain/controller/watcher_test.go
+++ b/domain/controller/watcher_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+	"gopkg.in/check.v1"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/controller/service"
+	"github.com/juju/juju/domain/controller/state"
+	modeltesting "github.com/juju/juju/domain/model/state/testing"
+	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type watcherSuite struct {
+	changestreamtesting.ControllerSuite
+}
+
+var _ = gc.Suite(&watcherSuite{})
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+func (s *watcherSuite) updateModelActiveStatus(c *gc.C, modelUUID string, status bool) error {
+	return s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, "UPDATE model SET activated = ? WHERE uuid = ?", status, modelUUID)
+		if err != nil {
+			return err
+		}
+		rowsAffected, err := res.RowsAffected()
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		return err
+	})
+}
+
+func (s *watcherSuite) updateModelName(c *gc.C, modelUUID string, newName string) error {
+	return s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, "UPDATE model SET name = ? WHERE uuid = ?", newName, modelUUID)
+		if err != nil {
+			return err
+		}
+		rowsAffected, err := res.RowsAffected()
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		return err
+	})
+}
+
+func (s *watcherSuite) TestWatchController(c *gc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	watchableDBFactory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model")
+	watcherFactory := domain.NewWatcherFactory(watchableDBFactory, logger)
+	st := state.NewState(func() (database.TxnRunner, error) { return watchableDBFactory() })
+	controllerSvc := service.NewService(st, watcherFactory)
+
+	watcher, err := controllerSvc.Watch(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(watcher, gc.NotNil)
+
+	type model struct {
+		UUID        string `db:"uuid"`
+		Activated   bool   `db:"activated"`
+		ModelTypeID int    `db:"model_type_id"`
+		Name        string `db:"name"`
+		CloudUUID   string `db:"cloud_uuid"`
+		LifeID      int    `db:"life_id"`
+		OwnerUUID   string `db:"owner_uuid"`
+	}
+
+	var testModel model
+	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "test-model").String()
+	err = s.updateModelActiveStatus(c, modelUUID, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	row := s.DB().QueryRow(`SELECT activated FROM model WHERE  uuid = ?`, modelUUID)
+	err = row.Scan(&testModel.Activated)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(testModel.Activated, jc.IsFalse)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
+
+	harness.AddTest(func(c *gc.C) {
+		// Update model active status.
+		err = s.updateModelActiveStatus(c, modelUUID, true)
+		c.Assert(err, jc.ErrorIsNil)
+
+		// Check if model active status is updated.
+		row := s.DB().QueryRow(`SELECT activated FROM model WHERE  uuid = ?`, modelUUID)
+		err = row.Scan(&testModel.Activated)
+
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(testModel.Activated, jc.IsFalse)
+	}, func(w watchertest.WatcherC[[]string]) {
+		// Get the change.
+		w.Check(
+			watchertest.StringSliceAssert(
+				modelUUID,
+			),
+		)
+	})
+
+	harness.Run(c, []string{"false"})
+}

--- a/domain/controller/watcher_test.go
+++ b/domain/controller/watcher_test.go
@@ -42,7 +42,7 @@ type model struct {
 	OwnerUUID   string `db:"owner_uuid"`
 }
 
-func (s *watcherSuite) TestWatchController(c *gc.C) {
+func (s *watcherSuite) TestWatchControllerDBModels(c *gc.C) {
 	logger := loggertesting.WrapCheckLog(c)
 	watchableDBFactory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model")
 	watcherFactory := domain.NewWatcherFactory(watchableDBFactory, logger)
@@ -106,13 +106,14 @@ func (s *watcherSuite) TestWatchController(c *gc.C) {
 		c.Check(testModel.UUID, gc.Equals, modelUUIDStr)
 		c.Check(testModel.Activated, jc.IsTrue)
 
-		// Insert into and update table that is not model.
-		res, err = tx.ExecContext(ctx, "Insert into cloud_type (id, type) values (100, 'testing')")
+		// Insert into table that is not model. This should not trigger a change event.
+		res, err = tx.ExecContext(ctx, "INSERT into cloud_type (id, type) values (100, 'testing')")
 		c.Assert(err, jc.ErrorIsNil)
 		rowsAffected, err = res.RowsAffected()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(int(rowsAffected), gc.Equals, 1)
 
+		// Update table that is not model. This should not trigger a change event.
 		res, err = tx.ExecContext(ctx, "UPDATE cloud_type SET type = 'test' WHERE id = 100")
 		c.Assert(err, jc.ErrorIsNil)
 		rowsAffected, err = res.RowsAffected()

--- a/domain/controller/watcher_test.go
+++ b/domain/controller/watcher_test.go
@@ -59,6 +59,50 @@ func (s *watcherSuite) updateModelName(c *gc.C, modelUUID string, newName string
 	})
 }
 
+func (s *watcherSuite) deleteModel(c *gc.C, modelUUID string) error {
+	return s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, "DELETE from model WHERE uuid = ?", modelUUID)
+		if err != nil {
+			return err
+		}
+		rowsAffected, err := res.RowsAffected()
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		return err
+	})
+}
+
+type model struct {
+	UUID        string `db:"uuid"`
+	Activated   bool   `db:"activated"`
+	ModelTypeID int    `db:"model_type_id"`
+	Name        string `db:"name"`
+	CloudUUID   string `db:"cloud_uuid"`
+	LifeID      int    `db:"life_id"`
+	OwnerUUID   string `db:"owner_uuid"`
+}
+
+func (s *watcherSuite) deleteModelWithDependencyTables(c *gc.C, ctx context.Context, tx *sql.Tx, testModel model) {
+	res, err := tx.ExecContext(ctx, "DELETE from user WHERE uuid = ?", testModel.OwnerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	rowsAffected, err := res.RowsAffected()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(int(rowsAffected), gc.Equals, 1)
+
+	res, err = tx.ExecContext(ctx, "DELETE from cloud WHERE uuid = ?", testModel.CloudUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	rowsAffected, err = res.RowsAffected()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(int(rowsAffected), gc.Equals, 1)
+
+	res, err = tx.ExecContext(ctx, "DELETE from model WHERE uuid = ?", testModel.UUID)
+	c.Assert(err, jc.ErrorIsNil)
+	rowsAffected, err = res.RowsAffected()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(int(rowsAffected), gc.Equals, 1)
+
+}
+
 func (s *watcherSuite) TestWatchController(c *gc.C) {
 	logger := loggertesting.WrapCheckLog(c)
 	watchableDBFactory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model")
@@ -70,47 +114,98 @@ func (s *watcherSuite) TestWatchController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(watcher, gc.NotNil)
 
-	type model struct {
-		UUID        string `db:"uuid"`
-		Activated   bool   `db:"activated"`
-		ModelTypeID int    `db:"model_type_id"`
-		Name        string `db:"name"`
-		CloudUUID   string `db:"cloud_uuid"`
-		LifeID      int    `db:"life_id"`
-		OwnerUUID   string `db:"owner_uuid"`
-	}
-
 	var testModel model
-	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "test-model").String()
-	err = s.updateModelActiveStatus(c, modelUUID, false)
+	modelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "test-model")
+	modelUUIDStr := modelUUID.String()
+	err = s.updateModelActiveStatus(c, modelUUIDStr, false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	row := s.DB().QueryRow(`SELECT activated FROM model WHERE  uuid = ?`, modelUUID)
+	// Ensure that the initial activated status of model is false.
+	row := s.DB().QueryRow(`SELECT activated FROM model WHERE  uuid = ?`, modelUUIDStr)
 	err = row.Scan(&testModel.Activated)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(testModel.Activated, jc.IsFalse)
 
-	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
+	wc := watchertest.NewNotifyWatcherC(c, watcher)
+	// s.updateModelActiveStatus(c, modelUUIDStr, true)
+	// wc.AssertOneChange()
 
-	harness.AddTest(func(c *gc.C) {
-		// Update model active status.
-		err = s.updateModelActiveStatus(c, modelUUID, true)
+	// s.updateModelName(c, modelUUIDStr, "new-name")
+	// wc.AssertOneChange()
+
+	// dbInitialModel := modeltesting.DbInitialModel{
+	// 	UUID: modelUUIDStr,
+	// }
+	// modeltesting.DeleteTestModel(c, s.TxnRunnerFactory(), dbInitialModel)
+	// wc.AssertOneChange()
+
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		defer tx.Rollback()
+		res, err := tx.ExecContext(ctx, "UPDATE model SET activated = ? WHERE uuid = ?", true, modelUUIDStr)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err := res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err = tx.ExecContext(ctx, "UPDATE model SET name = ? WHERE uuid = ?", "new-test-model", modelUUIDStr)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		selectModelQuery := `
+			SELECT uuid, activated, model_type_id, name, cloud_uuid, life_id, owner_uuid 
+			FROM model 
+			WHERE uuid = ?
+		`
+		row := tx.QueryRow(selectModelQuery, modelUUIDStr)
+		err = row.Scan(&testModel.UUID, &testModel.Activated, &testModel.ModelTypeID, &testModel.Name, &testModel.CloudUUID, &testModel.LifeID, &testModel.OwnerUUID)
 		c.Assert(err, jc.ErrorIsNil)
 
-		// Check if model active status is updated.
-		row := s.DB().QueryRow(`SELECT activated FROM model WHERE  uuid = ?`, modelUUID)
-		err = row.Scan(&testModel.Activated)
-
+		err = tx.Commit()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Check(testModel.Activated, jc.IsFalse)
-	}, func(w watchertest.WatcherC[[]string]) {
-		// Get the change.
-		w.Check(
-			watchertest.StringSliceAssert(
-				modelUUID,
-			),
-		)
+		return err
 	})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertNChanges(2)
 
-	harness.Run(c, []string{"false"})
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		defer tx.Rollback()
+
+		res, err := tx.ExecContext(ctx, "DELETE from user WHERE uuid = ?", testModel.OwnerUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err := res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err = tx.ExecContext(ctx, "DELETE from cloud_region WHERE cloud_uuid = ?", testModel.CloudUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err = tx.ExecContext(ctx, "DELETE from cloud_credential WHERE cloud_uuid = ?", testModel.CloudUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err = tx.ExecContext(ctx, "DELETE from cloud WHERE uuid = ?", testModel.CloudUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err = tx.ExecContext(ctx, "DELETE from model WHERE uuid = ?", testModel.UUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		err = tx.Commit()
+		c.Assert(err, jc.ErrorIsNil)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertOneChange()
 }

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -173,52 +173,6 @@ func CreateTestModel(
 }
 
 // DeleteTestModel is responsible for cleaning up a testing mode previously
-// // created with [CreateTestModel].
-// func DeleteTestModel(
-// 	c *gc.C,
-// 	txnRunner database.TxnRunnerFactory,
-// 	uuid coremodel.UUID,
-// ) {
-// 	runner, err := txnRunner()
-// 	c.Assert(err, jc.ErrorIsNil)
-
-// 	err = runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-// 		_, err := tx.ExecContext(ctx, `
-// 			DELETE FROM model_agent where model_uuid = ?
-// 		`, uuid)
-// 		if err != nil {
-// 			return err
-// 		}
-
-// 		_, err = tx.ExecContext(ctx, `
-// 			DELETE FROM model WHERE uuid = ?
-// 		`, uuid)
-// 		return err
-// 	})
-// 	c.Assert(err, jc.ErrorIsNil)
-// }
-
-type DbInitialModel struct {
-	// UUID is the universally unique identifier of the model.
-	UUID string `db:"uuid"`
-
-	// CloudUUID is the unique identifier for the cloud the model is on.
-	CloudUUID string `db:"cloud_uuid"`
-
-	// ModelType is the type of model.
-	ModelType string `db:"model_type"`
-
-	// LifeID the ID of the current state of the model.
-	LifeID int `db:"life_id"`
-
-	// Name is the human friendly name of the model.
-	Name string `db:"name"`
-
-	// OwnerUUID is the uuid of the user that owns this model in the Juju controller.
-	OwnerUUID string `db:"owner_uuid"`
-}
-
-// DeleteTestModel is responsible for cleaning up a testing mode previously
 // created with [CreateTestModel].
 func DeleteTestModel(c *gc.C, ctx context.Context, txnRunner database.TxnRunnerFactory, modelUUID coremodel.UUID) {
 	modelSt := modelstate.NewState(txnRunner)

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -172,6 +172,32 @@ func CreateTestModel(
 	return modelUUID
 }
 
+// DeleteTestModel is responsible for cleaning up a testing mode previously
+// // created with [CreateTestModel].
+// func DeleteTestModel(
+// 	c *gc.C,
+// 	txnRunner database.TxnRunnerFactory,
+// 	uuid coremodel.UUID,
+// ) {
+// 	runner, err := txnRunner()
+// 	c.Assert(err, jc.ErrorIsNil)
+
+// 	err = runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+// 		_, err := tx.ExecContext(ctx, `
+// 			DELETE FROM model_agent where model_uuid = ?
+// 		`, uuid)
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		_, err = tx.ExecContext(ctx, `
+// 			DELETE FROM model WHERE uuid = ?
+// 		`, uuid)
+// 		return err
+// 	})
+// 	c.Assert(err, jc.ErrorIsNil)
+// }
+
 type DbInitialModel struct {
 	// UUID is the universally unique identifier of the model.
 	UUID string `db:"uuid"`
@@ -194,51 +220,8 @@ type DbInitialModel struct {
 
 // DeleteTestModel is responsible for cleaning up a testing mode previously
 // created with [CreateTestModel].
-func DeleteTestModel(c *gc.C, txnRunner database.TxnRunnerFactory, dbInitialModel DbInitialModel) {
-
-	runner, err := txnRunner()
-	c.Assert(err, jc.ErrorIsNil)
-
-	runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		res, err := tx.ExecContext(ctx, "DELETE from user_authentication WHERE user_uuid = ?", dbInitialModel.OwnerUUID)
-		c.Assert(err, jc.ErrorIsNil)
-		rowsAffected, err := res.RowsAffected()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(int(rowsAffected), gc.Equals, 1)
-
-		res, err = tx.ExecContext(ctx, "DELETE from user WHERE uuid = ?", dbInitialModel.OwnerUUID)
-		c.Assert(err, jc.ErrorIsNil)
-		rowsAffected, err = res.RowsAffected()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(int(rowsAffected), gc.Equals, 1)
-
-		res, err = tx.ExecContext(ctx, "DELETE from cloud_region WHERE cloud_uuid = ?", dbInitialModel.CloudUUID)
-		c.Assert(err, jc.ErrorIsNil)
-		rowsAffected, err = res.RowsAffected()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(int(rowsAffected), gc.Equals, 1)
-
-		res, err = tx.ExecContext(ctx, "DELETE from cloud_credential WHERE cloud_uuid = ?", dbInitialModel.CloudUUID)
-		c.Assert(err, jc.ErrorIsNil)
-		rowsAffected, err = res.RowsAffected()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(int(rowsAffected), gc.Equals, 1)
-
-		res, err = tx.ExecContext(ctx, "DELETE from cloud WHERE uuid = ?", dbInitialModel.CloudUUID)
-		c.Assert(err, jc.ErrorIsNil)
-		rowsAffected, err = res.RowsAffected()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(int(rowsAffected), gc.Equals, 1)
-
-		res, err = tx.ExecContext(ctx, "DELETE from model WHERE uuid = ?", dbInitialModel.UUID)
-		c.Assert(err, jc.ErrorIsNil)
-		rowsAffected, err = res.RowsAffected()
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(int(rowsAffected), gc.Equals, 1)
-
-		err = tx.Commit()
-		c.Assert(err, jc.ErrorIsNil)
-		return nil
-	})
+func DeleteTestModel(c *gc.C, ctx context.Context, txnRunner database.TxnRunnerFactory, modelUUID coremodel.UUID) {
+	modelSt := modelstate.NewState(txnRunner)
+	err := modelSt.Delete(ctx, modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -226,17 +226,37 @@ func DeleteTestModel(c *gc.C, txnRunner database.TxnRunnerFactory, dbModel DbIni
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-			DELETE FROM user where uuid = ?
-		`, dbModel.OwnerUUID)
-		if err != nil {
-			return err
-		}
+		res, err := tx.ExecContext(ctx, "DELETE from user WHERE uuid = ?", dbModel.OwnerUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err := res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
 
-		_, err = tx.ExecContext(ctx, `
-			DELETE FROM model WHERE uuid = ?
-		`, dbModel.UUID)
-		return err
+		res, err = tx.ExecContext(ctx, "DELETE from cloud_region WHERE cloud_uuid = ?", dbModel.CloudUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err = tx.ExecContext(ctx, "DELETE from cloud_credential WHERE cloud_uuid = ?", dbModel.CloudUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err = tx.ExecContext(ctx, "DELETE from cloud WHERE uuid = ?", dbModel.CloudUUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		res, err = tx.ExecContext(ctx, "DELETE from model WHERE uuid = ?", dbModel.UUID)
+		c.Assert(err, jc.ErrorIsNil)
+		rowsAffected, err = res.RowsAffected()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(int(rowsAffected), gc.Equals, 1)
+
+		return tx.Commit()
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -173,26 +173,69 @@ func CreateTestModel(
 }
 
 // DeleteTestModel is responsible for cleaning up a testing mode previously
+// // created with [CreateTestModel].
+// func DeleteTestModel(
+// 	c *gc.C,
+// 	txnRunner database.TxnRunnerFactory,
+// 	uuid coremodel.UUID,
+// ) {
+// 	runner, err := txnRunner()
+// 	c.Assert(err, jc.ErrorIsNil)
+
+// 	err = runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+// 		_, err := tx.ExecContext(ctx, `
+// 			DELETE FROM model_agent where model_uuid = ?
+// 		`, uuid)
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		_, err = tx.ExecContext(ctx, `
+// 			DELETE FROM model WHERE uuid = ?
+// 		`, uuid)
+// 		return err
+// 	})
+// 	c.Assert(err, jc.ErrorIsNil)
+// }
+
+type DbInitialModel struct {
+	// UUID is the universally unique identifier of the model.
+	UUID string `db:"uuid"`
+
+	// CloudUUID is the unique identifier for the cloud the model is on.
+	CloudUUID string `db:"cloud_uuid"`
+
+	// ModelType is the type of model.
+	ModelType string `db:"model_type"`
+
+	// LifeID the ID of the current state of the model.
+	LifeID int `db:"life_id"`
+
+	// Name is the human friendly name of the model.
+	Name string `db:"name"`
+
+	// OwnerUUID is the uuid of the user that owns this model in the Juju controller.
+	OwnerUUID string `db:"owner_uuid"`
+}
+
+// DeleteTestModel is responsible for cleaning up a testing mode previously
 // created with [CreateTestModel].
-func DeleteTestModel(
-	c *gc.C,
-	txnRunner database.TxnRunnerFactory,
-	uuid coremodel.UUID,
-) {
+func DeleteTestModel(c *gc.C, txnRunner database.TxnRunnerFactory, dbModel DbInitialModel) {
+
 	runner, err := txnRunner()
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-			DELETE FROM model_agent where model_uuid = ?
-		`, uuid)
+			DELETE FROM user where uuid = ?
+		`, dbModel.OwnerUUID)
 		if err != nil {
 			return err
 		}
 
 		_, err = tx.ExecContext(ctx, `
 			DELETE FROM model WHERE uuid = ?
-		`, uuid)
+		`, dbModel.UUID)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/services/controller.go
+++ b/domain/services/controller.go
@@ -69,6 +69,7 @@ func NewControllerServices(
 func (s *ControllerServices) Controller() *controllerservice.Service {
 	return controllerservice.NewService(
 		controllerstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
+		s.controllerWatcherFactory("model"),
 	)
 }
 

--- a/internal/worker/modelworkermanager/manifold.go
+++ b/internal/worker/modelworkermanager/manifold.go
@@ -160,11 +160,15 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// domainServices, err := domainServicesGetter.ServicesForModel(context, model.UUID(systemState.ControllerModelUUID()))
+	// if err != nil {
+	// 	return nil, errors.Trace(err)
+	// }
 
 	w, err := config.NewWorker(Config{
 		Authority:    authority,
 		Logger:       config.Logger,
-		ModelWatcher: systemState,
+		SystemState:  systemState,
 		ModelMetrics: config.ModelMetrics,
 		Controller: StatePoolController{
 			StatePool: statePool,

--- a/internal/worker/modelworkermanager/manifold.go
+++ b/internal/worker/modelworkermanager/manifold.go
@@ -160,10 +160,6 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// domainServices, err := domainServicesGetter.ServicesForModel(context, model.UUID(systemState.ControllerModelUUID()))
-	// if err != nil {
-	// 	return nil, errors.Trace(err)
-	// }
 
 	w, err := config.NewWorker(Config{
 		Authority:    authority,

--- a/internal/worker/modelworkermanager/manifold_test.go
+++ b/internal/worker/modelworkermanager/manifold_test.go
@@ -169,7 +169,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 
 	c.Assert(config, jc.DeepEquals, modelworkermanager.Config{
 		Authority:    s.authority,
-		ModelWatcher: s.state,
+		SystemState:  s.state,
 		ModelMetrics: dummyModelMetrics{},
 		Controller: modelworkermanager.StatePoolController{
 			StatePool: s.pool,

--- a/internal/worker/modelworkermanager/modelworkermanager.go
+++ b/internal/worker/modelworkermanager/modelworkermanager.go
@@ -255,14 +255,6 @@ func (m *modelWorkerManager) modelChanged(modelUUID string) error {
 	}
 	defer release()
 
-	if !isModelActive(model) {
-		// Ignore this model until it's activated - we
-		// never want to run workers for an importing
-		// model.
-		// https://bugs.launchpad.net/juju/+bug/1646310
-		return nil
-	}
-
 	cfg := NewModelConfig{
 		Authority:    m.config.Authority,
 		ModelName:    model.Name(),

--- a/internal/worker/modelworkermanager/modelworkermanager_test.go
+++ b/internal/worker/modelworkermanager/modelworkermanager_test.go
@@ -46,7 +46,6 @@ func (s *suite) setupMocks(c *gc.C) *gomock.Controller {
 
 	s.domainServicesGetter = NewMockDomainServicesGetter(ctrl)
 	s.domainServices = NewMockDomainServices(ctrl)
-
 	return ctrl
 }
 
@@ -227,7 +226,7 @@ func (s *suite) runKillTest(c *gc.C, kill killFunc, test testFunc) {
 	config := modelworkermanager.Config{
 		Authority:              s.authority,
 		Logger:                 loggertesting.WrapCheckLog(c),
-		ModelWatcher:           watcher,
+		SystemState:            &state.State{},
 		Controller:             mockController,
 		NewModelWorker:         s.startModelWorker,
 		ModelMetrics:           dummyModelMetrics{},


### PR DESCRIPTION
This task is to integrate watcher into modelworkermanager. We will remove the client to the facade and the call to facade in exchange for using the service factory directly.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

 1. Bootstrap a 4.0 controller
```sh
$ juju bootstrap aws test
```

## Links

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-7400
